### PR TITLE
Support TLS SNI

### DIFF
--- a/src/app/libs/libManageSieve/SieveClient.mjs
+++ b/src/app/libs/libManageSieve/SieveClient.mjs
@@ -136,7 +136,8 @@ class SieveNodeClient extends SieveAbstractClient {
       // this.tlsSocket = tls.TLSSocket(socket, options).connect();
       this.tlsSocket = tls.connect({
         socket: this.socket,
-        rejectUnauthorized: false
+        servername: this.host,
+        rejectUnauthorized: false        
       });
 
       this.tlsSocket.on('secureConnect', () => {


### PR DESCRIPTION
For people using Pigeonhole on a Dovecot with [local_name certificates](https://doc.dovecot.org/configuration_manual/dovecot_ssl_configuration/#with-client-tls-sni-server-name-indication-support).